### PR TITLE
Renamed the 'client' and 'server' constants

### DIFF
--- a/packages/client/types/client.d.ts
+++ b/packages/client/types/client.d.ts
@@ -1,4 +1,4 @@
-declare const client: IClient;
+declare const CLIENT: IClient;
 
 declare interface IClient {
     registerSystem<TSystem extends IClientSystem<TSystem> = IVanillaClientSystem>(majorVersion: number, minorVersion: number): TSystem;

--- a/packages/server/types/server.d.ts
+++ b/packages/server/types/server.d.ts
@@ -1,4 +1,4 @@
-declare const server: IServer;
+declare const SERVER: IServer;
 
 declare interface IServer {
     registerSystem<TSystem extends IServerSystem<TSystem> = IVanillaServerSystem>(majorVersion: number, minorVersion: number): TSystem;


### PR DESCRIPTION
 ... so they don't conflict with for example 'namespace client {}' or 'namespace server {}' in projects where these types are used

-> typescript naming conventions
